### PR TITLE
Reset validation errors to undefined when no errors are returned

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,11 +31,14 @@
     "ava": "^0.7.0",
     "babel": "^5.8.34",
     "browserify": "^12.0.1",
+    "enzyme": "^2.4.1",
     "nyc": "^5.0.1",
+    "react-addons-test-utils": "^15.3.0",
+    "react-dom": "^15.3.0",
     "standard": "^5.4.1"
   },
   "dependencies": {
     "invariant": "^2.2.0",
-    "react": "^0.14.3"
+    "react": "^15.3.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -36,9 +36,7 @@ function validateState (state, displayName, validations) {
       displayName,
       validations
     })
-    if (validation) {
-      state.errors[key] = flattenErrors(validation)
-    }
+    state.errors[key] = flattenErrors(validation)
   }
   return state
 }
@@ -55,7 +53,9 @@ function flattenErrors (err) {
   if (typeof err === 'object' && err.length) {
     return err.map((_err) => _err.message)
   }
-  return [err.message]
+  if (err) {
+    return [err.message]
+  }
 }
 
 export {stateValidation, validateKey, flattenErrors}

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -3,6 +3,9 @@
 import test from 'ava'
 import {stateValidation, validateKey, flattenErrors} from '../lib'
 
+import React, { Component } from 'react'
+import { shallow, mount } from 'enzyme';
+
 test('the stateValidation method is a function', t => {
   t.is(typeof stateValidation, 'function')
   t.pass()
@@ -75,6 +78,31 @@ test('the stateValidation method should pass back an array with strings in it if
   const Qux = stateValidation(Foo)
   const qux = new Qux()
   qux.setState({foo: 'bar'})
+})
+
+test('the stateValidation method should reset validation errors to undefined when no errors are returned', t => {
+  class Foo extends Component {
+    render() {
+      return <div></div>
+    }
+  }
+  Foo.stateValidations = {
+    foo: (state, stateKey, componentName) => {
+      if(!state[stateKey]) {
+        return new Error('error')
+      }
+    }
+  }
+  const Qux = stateValidation(Foo)
+  const qux = shallow(<Qux />)
+  qux.setState({foo: ''})
+  qux.setState({foo: 'bar'})
+
+  const _state = qux.state();
+  t.is(typeof _state, 'object')
+  t.is(typeof _state.errors, 'object')
+  t.is(_state.errors.foo, undefined)
+  t.pass()
 })
 
 test('the stateValidation method should pass back an array with many strings if an array of errors is passed back from validation', t => {


### PR DESCRIPTION
I found issue where validations errors weren't properly cleared after an error was fixed by the user.
